### PR TITLE
#59 Fixed team page and Merch page colouring to a lighter dark

### DIFF
--- a/src/components/Merch/MerchPageContent.tsx
+++ b/src/components/Merch/MerchPageContent.tsx
@@ -10,11 +10,11 @@ const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
 const MerchPageContent = () => {
   return (
     <div
-      className="flex flex-col items-center justify-center"
+      className="flex flex-col items-center justify-center bg-dark-background"
       id="merchPageTop"
     >
       {/* Header Section */}
-      <div className="mb-8 flex w-full flex-col items-center bg-black pb-32">
+      <div className="mb-8 flex w-full flex-col items-center bg-dark-background pb-32">
         <div className="flex w-full items-center justify-center">
           <div className="w-full max-w-xl">
             <Lottie {...merchPageLottieOptions} />

--- a/src/pageLayouts/TeamPage.tsx
+++ b/src/pageLayouts/TeamPage.tsx
@@ -19,7 +19,7 @@ const TeamPage = () => {
 
   return (
     <div
-      className="relative box-border h-full overflow-hidden scroll-smooth whitespace-normal border-none bg-black p-0 font-sans leading-6"
+      className="relative box-border h-full overflow-hidden scroll-smooth whitespace-normal border-none bg-dark-background p-0 font-sans leading-6"
       id="teamPageTop"
     >
       <Blobbie


### PR DESCRIPTION
Fixes issue #59 

Made all the pages consistent in colour. Branch name is 50-Team-Page-Grey-Colour but I ment to name it 59

Before:

<img width="591" height="229" alt="image" src="https://github.com/user-attachments/assets/2bbedb99-7c18-41cc-ab97-8b223b25a523" />

After (Also did it for the merch page):

<img width="594" height="187" alt="image" src="https://github.com/user-attachments/assets/868b6135-8faa-44bc-ad49-f20251258639" />
